### PR TITLE
Add initial network orchestrator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wingbeat"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.11", features = ["json", "tokio-runtime"] }
+anyhow = "1"
+async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Wingbeat
-A protocol where subgraphs of computation graphs have subgraphs split off, distribute the subgraphs as the main node, the subgraphs are then computed in this distributed nodes; after, the head node collects the results and complete the computation.  It may evolve into a knowledge. civilization.
+
+Wingbeat aims to orchestrate distributed computation across a network of nodes. 
+Subgraphs of a computation graph are delegated to remote nodes and the results 
+are gathered to complete the overall computation. This repository currently 
+contains a minimal Rust implementation that demonstrates the initial 
+networking layer.
+
+## Building
+
+```bash
+cargo build
+```
+
+## Running the Example
+
+The current binary sends a demo task to a hypothetical node using HTTP. It 
+serves as the first step toward a decentralized orchestration layer.
+
+```bash
+cargo run
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,25 @@
+mod orchestrator;
+
+use orchestrator::{Node, Orchestrator, TaskMessage};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Example usage of the orchestrator
+    let orchestrator = Orchestrator::new();
+
+    let node = Node {
+        id: "node-1".into(),
+        endpoint: "http://localhost:8080/task".into(),
+    };
+
+    let msg = TaskMessage {
+        task_id: "demo".into(),
+        payload: json!({"example": true}),
+    };
+
+    // Ignoring errors for this demo
+    let _ = orchestrator.dispatch_task(&node, &msg).await;
+
+    Ok(())
+}

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+/// Represents a remote node in the Wingbeat network.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub id: String,
+    pub endpoint: String,
+}
+
+/// Basic message that can be sent between nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskMessage {
+    pub task_id: String,
+    pub payload: serde_json::Value,
+}
+
+/// Orchestrator handles communication with nodes.
+#[derive(Debug, Default)]
+pub struct Orchestrator {
+    client: Client,
+}
+
+impl Orchestrator {
+    /// Create a new orchestrator.
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    /// Send a task to a remote node asynchronously.
+    pub async fn dispatch_task(&self, node: &Node, msg: &TaskMessage) -> Result<()> {
+        self.client
+            .post(&node.endpoint)
+            .json(msg)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add a `Cargo.toml` with common networking crates
- implement `Orchestrator` and basic message structs
- demonstrate usage in `main.rs`
- expand README with build and run instructions

## Testing
- `cargo build` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68491d1836108330b115a2c921ab0cad